### PR TITLE
Add word boundary to match full word

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A better, simple PO Box Filter that is built around real-world address problems.
 
 # The RegEx
 ````JavaScript
-/(?:P(?:ost(?:al)?)?[\.\-\s]*(?:(?:O(?:ffice)?[\.\-\s]*)?B(?:ox|in|\b|\d)|o(?:ffice|\b)(?:[-\s]*\d)|code)|box[-\s\b]*\d)/i
+/\b(?:P(?:ost(?:al)?)?[\.\-\s]*(?:(?:O(?:ffice)?[\.\-\s]*)?B(?:ox|in|\b|\d)|o(?:ffice|\b)(?:[-\s]*\d)|code)|box[-\s\b]*\d)/i
 ````
 
 # Positive List


### PR DESCRIPTION
Without the word boundary `\b`, the regex matches "soapbox". It should not match the end of the word "soapbox"